### PR TITLE
Fix missing purchase order converter bean in tests

### DIFF
--- a/src/test/java/com/iron/tec/labs/ecommercejava/config/ConverterConfig.java
+++ b/src/test/java/com/iron/tec/labs/ecommercejava/config/ConverterConfig.java
@@ -146,6 +146,11 @@ public class ConverterConfig {
         return new PurchaseOrderDomainToEntity(conversionService);
     }
 
+    @Bean
+    public PurchaseOrderEntityToDomain purchaseOrderEntityToDomain(ConversionService conversionService) {
+        return new PurchaseOrderEntityToDomain(conversionService);
+    }
+
     // Purchase order line converters
     @Bean
     public GetPurchaseOrderLineViewMapper getPurchaseOrderLineViewMapper() {

--- a/src/test/java/com/iron/tec/labs/ecommercejava/db/DatabaseAccessConfig.java
+++ b/src/test/java/com/iron/tec/labs/ecommercejava/db/DatabaseAccessConfig.java
@@ -9,6 +9,7 @@ import com.iron.tec.labs.ecommercejava.db.repository.*;
 import com.iron.tec.labs.ecommercejava.db.rowmappers.ColumnConverter;
 import com.iron.tec.labs.ecommercejava.db.rowmappers.ProductRowMapper;
 import com.iron.tec.labs.ecommercejava.mappers.purchase.order.PurchaseOrderDomainToEntity;
+import com.iron.tec.labs.ecommercejava.mappers.purchase.order.PurchaseOrderEntityToDomain;
 import com.iron.tec.labs.ecommercejava.mappers.purchase.order.line.PurchaseOrderLineDomainToEntity;
 import com.iron.tec.labs.ecommercejava.services.MessageService;
 import org.springframework.boot.SpringApplication;
@@ -63,10 +64,15 @@ public class DatabaseAccessConfig {
 		return new ObjectMapper();
     }
 
-	@Bean
-	public PurchaseOrderDomainToEntity purchaseOrderDomainToEntity(PurchaseOrderLineDomainToEntity conversionService) {
-		return new PurchaseOrderDomainToEntity(conversionService);
-	}
+        @Bean
+        public PurchaseOrderDomainToEntity purchaseOrderDomainToEntity(PurchaseOrderLineDomainToEntity conversionService) {
+                return new PurchaseOrderDomainToEntity(conversionService);
+        }
+
+        @Bean
+        public PurchaseOrderEntityToDomain purchaseOrderEntityToDomain(ConversionService conversionService) {
+                return new PurchaseOrderEntityToDomain(conversionService);
+        }
 
 	@Bean
 	public PurchaseOrderLineDomainToEntity purchaseOrderLineDomainToEntity() {


### PR DESCRIPTION
## Summary
- register `PurchaseOrderEntityToDomain` in test ConverterConfig
- add same bean in DatabaseAccessConfig for integration tests

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6854bdecd24c8328b05ed50c2dd033f6